### PR TITLE
Prisma server update for passport.js - oauth MVP

### DIFF
--- a/backend/prisma/datamodel.prisma
+++ b/backend/prisma/datamodel.prisma
@@ -3,7 +3,7 @@ type User {
   name: String
   nickname: String
   email: String
-  twitterHandle: String
+  twitterHandle: String @unique
   scratchingAutomated: Boolean @default(value: "false")
   isPrivate: Boolean @default(value: "false")
   visits: [Visit] @relation(name: "UserCountries")

--- a/backend/prisma/generated/prisma-client/index.d.ts
+++ b/backend/prisma/generated/prisma-client/index.d.ts
@@ -717,6 +717,7 @@ export interface VisitUpdateWithWhereUniqueWithoutUserInput {
 
 export type UserWhereUniqueInput = AtLeastOne<{
   id: ID_Input;
+  twitterHandle?: String;
 }>;
 
 export interface VisitUpdateWithoutUserDataInput {

--- a/backend/prisma/generated/prisma-client/prisma-schema.js
+++ b/backend/prisma/generated/prisma-client/prisma-schema.js
@@ -603,6 +603,7 @@ input UserWhereInput {
 
 input UserWhereUniqueInput {
   id: ID
+  twitterHandle: String
 }
 
 type Visit {

--- a/backend/services/passport/passport.js
+++ b/backend/services/passport/passport.js
@@ -23,7 +23,6 @@ module.exports = async prisma => {
         proxy: true
       },
       async (token, tokenSecret, profile, done) => {
-        console.log(profile)
         const existingUser = await prisma.user({
           twitterHandle: profile.displayName
         })


### PR DESCRIPTION
# Description

Fixes the issue of looking a user through a twitterHandle in our Twitter passport strategy -> twitterHandle was not unique originally, causing Prisma to freeze the request. Twitter oauth should redirect the user to the settings page on successful redirect.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ ] Complete, tested, ready to review and merge
- [X] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Need to test the oauth-flow with production/deployed versions of Backpaca.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts