### PR TITLE
Update profile.displayName to profile.username in Twitter Passport Strategy

### DIFF
--- a/backend/services/passport/passport.js
+++ b/backend/services/passport/passport.js
@@ -24,13 +24,13 @@ module.exports = async prisma => {
       },
       async (token, tokenSecret, profile, done) => {
         const existingUser = await prisma.user({
-          twitterHandle: profile.displayName
+          twitterHandle: profile.username
         })
         if (existingUser) {
           done(null, existingUser)
         } else {
           const createdUser = await prisma.createUser({
-            twitterHandle: profile.displayName
+            twitterHandle: profile.username
           })
           done(null, createdUser)
         }


### PR DESCRIPTION
# Description

[Trello Card](https://trello.com/c/fNbCdUi2/79-fix-passport-createuser-logic)

Changed the Twitter Passport strategy to add our profile.username to the server instead of the profile.displayName. Cleared the incorrect data on Prisma.

## Type of change

- [X] Issue fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts