### PR TITLE
Fix crashing when draw is invoked before client rectangles are assigned

### DIFF
--- a/frontend/components/Scratcher/utilities.js
+++ b/frontend/components/Scratcher/utilities.js
@@ -13,6 +13,13 @@
 */
 
 //-- Project Constants ---------------------------
+const RESOLUTION_DEFAULT = 25;
+/* RESOLUTION_DEFAULT: If draw is invoked before client rectangles have been
+    determined, then resize will fail with a width and height of 0. As a
+    temporary fix, a default resolution will be used instead. Note, however,
+    that this will result in a garbled display. The underlying problem should be
+    addressed instead, which is that React is invoking ComponentDidMount before
+    client rectangles have been assigned. */
 const URI_COUNTRY_ALPHA = '/static/country-alpha';
 /* URI_COUNTRY_ALPHA: The uri from which alpha masks can be loaded. This is
     probably a subdirectory under a "static" or "public" directory. */
@@ -48,6 +55,10 @@ export function initializeCanvas(drawingState, movementHandler) {
     const bounds = canvas.getBoundingClientRect();
     canvas.width  = bounds.right  - bounds.left;
     canvas.height = bounds.bottom - bounds.top ;
+    if(!canvas.width || !canvas.height) {
+      canvas.width  = RESOLUTION_DEFAULT;
+      canvas.height = RESOLUTION_DEFAULT;
+    }
     // Add event listeners for sratching actions
     canvas.addEventListener(
         'mousemove',


### PR DESCRIPTION
# Description

Mitigates bug in #93 by assigning a minimum resolution of 25px. This should prevent crashes, but will still result in poor rending quality whenever the bug is encountered.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, but not tested (may need new tests)

# How Has This Been Tested?

Our project isn't configured to use automated testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts