### PR TITLE
Clear Visit Button on Modal; Visit Count on Friend & User Card

### DIFF
--- a/frontend/components/CountryModal/ClearVisitButton.js
+++ b/frontend/components/CountryModal/ClearVisitButton.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { Button } from 'semantic-ui-react'
+import { Query, Mutation } from 'react-apollo';
+import { 
+  MUTATION_DELETEVISIT_MODAL, 
+  QUERY_USERVISITS_MODAL } from '../../services/requests/modal';
+
+const ClearVisitButton = ({ countryId, userId, disabled }) => {
+  return (
+    disabled ? <Button>View Friend's Profile</Button> :
+    (
+      <Query query={QUERY_USERVISITS_MODAL} variables={{id: userId}}>
+        {({ loading, data: {user} }) => {
+          if (loading) return <div>Loading</div>
+          let visits = user.visits
+          let visit = visits.find(visit => visit.country.id === countryId)
+          let visitId = visit.id
+          return (
+            <Mutation 
+              mutation={MUTATION_DELETEVISIT_MODAL} 
+              variables={{ id: visitId }}
+              update={(cache, {data}) => {
+                const result = cache.readQuery({ query: QUERY_USERVISITS_MODAL, variables: {id: userId} });
+                const deletedVisit = data.deleteVisit
+                const visits = result.user.visits
+                cache.writeQuery({
+                  query: QUERY_USERVISITS_MODAL,
+                  variables: {id: userId},
+                  data: { visits: visits.filter(visit => visit.id !== deletedVisit.id) },
+                });
+              }}
+            >
+              {deleteVisit => (
+                <Button
+                  negative
+                  onClick={deleteVisit}
+                >Clear Visit</Button>
+              )}
+            </Mutation>
+          )
+        }}
+      </Query>
+    )
+  )
+}
+
+export default ClearVisitButton;

--- a/frontend/components/CountryModal/ClearVisitButton.js
+++ b/frontend/components/CountryModal/ClearVisitButton.js
@@ -1,13 +1,18 @@
 import React from 'react'
 import { Button } from 'semantic-ui-react'
+import { Router } from '../../services/routes';
 import { Query, Mutation } from 'react-apollo';
 import { 
   MUTATION_DELETEVISIT_MODAL, 
   QUERY_USERVISITS_MODAL } from '../../services/requests/modal';
 
-const ClearVisitButton = ({ countryId, userId, disabled }) => {
+const ClearVisitButton = ({ countryId, userId, friendId, disabled }) => {
   return (
-    disabled ? <Button>View Friend's Profile</Button> :
+    disabled ? 
+    <Button 
+      onClick={() => Router.pushRoute('friends', {id: friendId})}
+    >View Friend's Profile</Button>
+    :
     (
       <Query query={QUERY_USERVISITS_MODAL} variables={{id: userId}}>
         {({ loading, data: {user} }) => {

--- a/frontend/components/CountryModal/CountryModal.js
+++ b/frontend/components/CountryModal/CountryModal.js
@@ -55,6 +55,7 @@ export default class CountryModal extends Component {
               <ClearVisitButton 
                 countryId={data.countryId}
                 userId={data.userId}
+                friendId={data.friendId}
                 disabled={disabled}
               />
             </Card.Content>

--- a/frontend/components/CountryModal/CountryModal.js
+++ b/frontend/components/CountryModal/CountryModal.js
@@ -17,6 +17,7 @@ import Header from './Header';
 import { QUERY_CLIENT_MODAL } from '../../services/requests/modal';
 import './countryModal.less'
 import ScratchHandler from './ScratchHandler.js';
+import ClearVisitButton from './ClearVisitButton';
 
 //-- React Implementation ------------------------
 export default class CountryModal extends Component {
@@ -50,6 +51,11 @@ export default class CountryModal extends Component {
               <FriendsVisits
                 id={data.countryId}
                 displayId={displayId}
+              />
+              <ClearVisitButton 
+                countryId={data.countryId}
+                userId={data.userId}
+                disabled={disabled}
               />
             </Card.Content>
           </div>

--- a/frontend/components/CountryModal/countryModal.less
+++ b/frontend/components/CountryModal/countryModal.less
@@ -9,11 +9,10 @@
   align-items: center;
   justify-content: space-between;
   left: 5%;
-  min-width: 15%;
+  min-width: 240px;
   overflow-y: hidden;
   position: absolute;
   z-index: 500;
-
 
   @media (max-width: 500px) {
     bottom: 0;
@@ -91,5 +90,4 @@
     // }
 
   }
-
 }

--- a/frontend/components/Friends/friendsCard.js
+++ b/frontend/components/Friends/friendsCard.js
@@ -9,7 +9,6 @@ import {
   QUERY_FRIEND_PROFILE,
   MUTATION_VIEWFRIEND_PROFILE } from '../../services/requests/profile';
 
-
 export default class Friends extends Component {
   constructor(props) {
     super(props)
@@ -18,30 +17,29 @@ export default class Friends extends Component {
   //the current user that is logged in
   userId = this.props.currentUserId
   //list of friends of the logged in user
-  data = this.props.friendsData
+  friendList = this.props.friendsData
 
   
   friends = (id, name) => {   
-    let friends = false
-    for (let i=0; i<this.data.length; i++) {
-      if(this.data[i].id === id) {
-        friends = true
+    let isFriends = false
+    this.friendList.forEach(friend => {
+      if (friend.id === id) {
+        isFriends = true
       }
-    }
+    })
 
-    if(friends === true) {
+    if(isFriends) {
       return (
         <Fragment>
           <a>
             <Icon name='user'/>
-            12
             <DeleteFriendButton userId={this.userId} friendId={id} />
           </a>
           <Mutation mutation={MUTATION_VIEWFRIEND_PROFILE} variables={{id: id}}>
             {viewFriend => (
               <Button
               onClick={() => {
-                viewFriend()
+                // viewFriend()
                 // Router.pushRoute('travels')
               }}
             >
@@ -52,11 +50,11 @@ export default class Friends extends Component {
         </Fragment>
       )
     }
-    if(friends === false) {
+
+    if(!isFriends) {
       return (
         <a>
           <Icon name='user'/>
-          12
           <AddFriendButton userId={this.userId} friendId={id} />
         </a>
       )
@@ -74,12 +72,13 @@ export default class Friends extends Component {
                   if (loadingFriendId || loadingUser) {
                   return <div>loading...</div>
                 }
+                const visitCount = user.visits.length
                 return (
                   <div>
                     <Card 
                     image='/static/alpaca.png'
                     header={user.name}
-                    meta='number of visits'
+                    meta={visitCount === 1 ? `${visitCount} Visit` : `${visitCount} Visits`}
                     description={user.bio === null ? null : user.bio}
                     extra={this.friends(friendId, user.name)}
                     />

--- a/frontend/components/Profile/FriendsList.js
+++ b/frontend/components/Profile/FriendsList.js
@@ -10,6 +10,7 @@ import React from 'react';
 import { List, Image, Button, Icon } from 'semantic-ui-react';
 import { Mutation } from 'react-apollo';
 import { 
+  QUERY_FRIENDS_PROFILE,
   MUTATION_DELETEFRIEND_PROFILE,
   MUTATION_FRIEND_PROFILE } from '../../services/requests/profile';
 import { Router } from '../../services/routes.js'

--- a/frontend/components/Profile/UserCard.js
+++ b/frontend/components/Profile/UserCard.js
@@ -34,9 +34,15 @@ export default class UserCard extends Component {
   }
   componentDidMount() {
     const user = this.props.user;
-    const { name, email, nickname, scratchingAutomated, isPrivate, pictureUrl, bio } = user;
-    this.setState({ name, email, nickname, scratchingAutomated, isPrivate, pictureUrl, bio });
-    // Is there a reason not to pass user instead of deconstruct/reconstruct it?
+    this.setState({ 
+      name: user.name, 
+      email: user.email, 
+      nickname: user.nickname, 
+      scratchingAutomated: user.scratchingAutomated, 
+      isPrivate: user.isPrivate, 
+      pictureUrl: user.pictureUrl, 
+      bio: user.bio 
+    });
   }
 
   //-- Interaction ---------------------------------
@@ -45,8 +51,6 @@ export default class UserCard extends Component {
       [changeEvent.target.name]: changeEvent.target.value,
     });
   }
-
-
 
   //uploads the image and sends back the url of the uploaded image
   uploadWidget = (e) => {
@@ -72,13 +76,15 @@ export default class UserCard extends Component {
   //-- Rendering -----------------------------------
   render() {
     const { joinDate, name, email, nickname, scratchingAutomated, isPrivate, editing, pictureUrl, bio } = this.state;
+    const visitCount = this.props.user.visits.length
     return (
       <Card className='profile_userCardMain'>
         <Image src={pictureUrl === '' ? '/static/alpaca.png' : pictureUrl} className='profile_userCardProfilePic' />
         <Card.Content>
           <Card.Header>{name}</Card.Header>
           <Card.Meta>
-            <span className='date'>Joined in {joinDate}</span>
+            <div>Joined in {joinDate}</div>
+            <div>{visitCount === 1 ? `${visitCount} Visit` : `${visitCount} Visits`}</div>
           </Card.Meta>
           {editing ? (
             <Fragment>

--- a/frontend/services/requests/profile.js
+++ b/frontend/services/requests/profile.js
@@ -36,6 +36,9 @@ export const QUERY_USER_PROFILE = gql`
       isPrivate
       bio
       pictureUrl
+      visits {
+        id
+      }
     }
   }
 `


### PR DESCRIPTION
# Description
* Clear visit button on modal deletes visits on your map
* If you're viewing a friend's map, the button is instead a "Visit Friend's Profile" button
* Included update for visits query, but similar to createVisit, the writeQuery does not seem to update the card data when you leave the modal and return to it
* Changed modal to fixed (px) min-width because scratcher is fixed width, which should always fit comfortably inside the modal
* Added visit count on user card and friend cards

[Trello Card](https://trello.com/c/0w8rFxA8/165-add-clear-visit-button-to-modal)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [X] Tested in dev

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts