### PR TITLE
Fix bug whereby scratcher wouldn't scratch

### DIFF
--- a/frontend/components/Scratcher/utilities.js
+++ b/frontend/components/Scratcher/utilities.js
@@ -52,13 +52,16 @@ export function initializeCanvas(drawingState, movementHandler) {
     // Setup Main canvas and drawing context
     const canvas = drawingState.displayCanvas;
     // Determine dimensions of available drawing container
-    //const bounds = canvas.getBoundingClientRect();
-    canvas.width  = 200;//bounds.right  - bounds.left;
-    canvas.height = 200;//bounds.bottom - bounds.top ;
-    /*if(!canvas.width || !canvas.height) {
+    const bounds = canvas.getBoundingClientRect();
+    canvas.width  = bounds.right  - bounds.left;
+    canvas.height = bounds.bottom - bounds.top ;
+    // Enforce lower bound for canvas resolution
+    if(canvas.width  < RESOLUTION_DEFAULT) {
       canvas.width  = RESOLUTION_DEFAULT;
+    }
+    if(canvas.height < RESOLUTION_DEFAULT) {
       canvas.height = RESOLUTION_DEFAULT;
-    }*/
+    }
     // Add event listeners for sratching actions
     canvas.addEventListener(
         'mousemove',
@@ -149,14 +152,16 @@ export function checkSize(drawingState) {
     const oldHeight = canvas.height;
     const newWidth  = bounds.right  - bounds.left;
     const newHeight = bounds.bottom - bounds.top ;
-    //if(newWidth === oldWidth && newHeight === oldHeight) { return;}
+    if(newWidth  < RESOLUTION_DEFAULT){ newWidth  = RESOLUTION_DEFAULT;}
+    if(newHeight < RESOLUTION_DEFAULT){ newHeight = RESOLUTION_DEFAULT;}
+    if(newWidth === oldWidth && newHeight === oldHeight) { return;}
     // Redraw outline at larger size
-    canvas.width  = 200;//newWidth ;
-    canvas.height = 200;//newHeight;
-    compositingContext.canvas.width  = 200;//newWidth ;
-    compositingContext.canvas.height = 200;//newHeight;
-    conversionContext.canvas.width  = 200;//newWidth ;
-    conversionContext.canvas.height = 200;//newHeight;
+    canvas.width  = newWidth ;
+    canvas.height = newHeight;
+    compositingContext.canvas.width  = newWidth ;
+    compositingContext.canvas.height = newHeight;
+    conversionContext.canvas.width  = newWidth ;
+    conversionContext.canvas.height = newHeight;
     generateOutline(drawingState);
     // Redraw scratch layer at larger size
     createScratchLayer(drawingState);


### PR DESCRIPTION
# Description

https://trello.com/c/HfH7R96O/136-fix-scratcher

Fixes a bug whereby the scratcher wouldn't update. The problem was that I remove the resizing logic by continually setting the size to 200px - and assigning a value to the width or height of a canvas, even to the same value it already has, results in a blanking of the drawing context.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, but not tested (may need new tests)

# How Has This Been Tested?

Our project is not configured to use automatic testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts