### PR TITLE
Make colors update on map after scratching

### DIFF
--- a/frontend/src/components/CountryModal/ScratchHandler.js
+++ b/frontend/src/components/CountryModal/ScratchHandler.js
@@ -81,14 +81,28 @@ export default class extends React.Component {
           level: this.state.itchyLevel,
         },
         update: (cache, {data: {createVisit}}) => {
-          const result = cache.readQuery({ query: QUERY_USERVISITS_MODAL, variables: {id: this.props.displayId } });
+          console.log("7: Create New");
+          const result = cache.readQuery({
+            query: QUERY_USERVISITS_MODAL,
+            variables: {id: this.props.displayId }
+          });
           const visits = result.user.visits
           const newVisit = createVisit
-          cache.writeQuery({
+          const updateData = {
             query: QUERY_USERVISITS_MODAL,
             variables: {id: result.user.id },
-            data: {user: {id: result.user.id, scratchingAutomated: result.user.scratchingAutomated, visits: [...visits, newVisit], __typename: 'Visit'}, __typename: 'User'}
-          });
+            data: {
+              user: {
+                id: result.user.id,
+                scratchingAutomated: result.user.scratchingAutomated,
+                visits: [...visits, newVisit],
+                __typename: 'Visit'
+              },
+                __typename: 'User'
+            }
+          }
+          console.log("Update Data:",updateData)
+          cache.writeQuery(updateData);
         }
       };
     // Handle update visit mutations (user already has data for country)
@@ -98,14 +112,26 @@ export default class extends React.Component {
           id: visitId,
           level: this.state.itchyLevel,
         },
-        update: (cache, {data: {updateVisit}}) => {
+        update: (cache, response) => {
+          const updateVisit = response.data.updateVisit;//{data: {updateVisit}}
+          console.log("7: Update Visit");
           const result = cache.readQuery({ query: QUERY_USERVISITS_MODAL, variables: {id: this.props.displayId } });
           const visits = result.user.visits
           const level = updateVisit['level']
+          console.log("Response",response)
+          const writeData = {
+            user: {
+              id: result.user.id,
+              scratchingAutomated: result.user.scratchingAutomated,
+              visits: visits.map(v => v.id === visitId ? {...v, level} : v),
+              __typename: 'User'
+            }
+          }
+          console.log("Write Data", writeData)
           cache.writeQuery({
             query: QUERY_USERVISITS_MODAL,
             variables: {id: result.user.id },
-            data: {user: {id: result.user, scratchingAutomated: result.user.scratchingAutomated, visits: visits.map(v => v.id === visitId ? {...v, level} : v), __typename: 'Visit'}, __typename: 'User'}
+            data: writeData
           });
         }
       };
@@ -175,6 +201,7 @@ export default class extends React.Component {
                 gqlMutation = MUTATION_UPDATEVISIT_MODAL;
               }
               // Display Scratchable Country and Visit Slider
+              console.log("Rendering Scratch Handler Mutation")
               return (
                 <div className="scratch-handler">
                   <Mutation mutation={gqlMutation}>{mutationInvocation => (

--- a/frontend/src/components/Map/StaticMap.js
+++ b/frontend/src/components/Map/StaticMap.js
@@ -105,7 +105,7 @@ export default class WorldMap extends React.Component {
 
   //-- Final React Render --------------------------
   render() {
-
+    console.log("Rendering Static Map")
     return (
       <Map
         className="map"
@@ -147,8 +147,8 @@ export default class WorldMap extends React.Component {
                       }}
                       data={feature}
                       style={hoverStyle}
-                      />
-                      {this.state.hovering}
+                    />
+                    {this.state.hovering}
                     </Label>
               )}
               </Mutation>
@@ -166,7 +166,7 @@ export default class WorldMap extends React.Component {
           const feature = getFeature(geojson, visit[2])
           return (
             <GeoJSON
-            key={visit[0]}
+            key={`${visit[0]}${Math.random()}`}
             data={feature}
             style={style}
             />)
@@ -180,7 +180,11 @@ export default class WorldMap extends React.Component {
               color: colors[level]
             }
             const feature = getFeature(geojson, visit[2]);
-            return (<GeoJSON key={visit[0]} data={feature} style={style}/>)
+            return (<GeoJSON
+              key={`${visit[0]}${Math.random()+1}`}
+              data={feature}
+              style={style}
+            />)
           })
         }
       </Map>


### PR DESCRIPTION
# Description

The map wasn't appearing to change color properly after changes in visitation level. I found three possible causes for this issue, all of which would need to be fixed in order to notice any progress toward fixing the issue. 

The first was that countries can sometimes have multiple visits, for reasons currently unknown to me. Visits drawn on top will obscure changes in visit level to visits draw lower (in z level). I was unable to address this issue, but it seems to be legacy data in the database, and new users may not encounter the same problem. For the sake of these tests, we used countries I hadn't visited previously, or countries with only one registered visit.

The second issue was that the data supplied to the update function (for mutations) wasn't structured properly: the "__typename" property was incorrect, and a full user object was being passed instead of a user id.

The third issue was that GeoJSON objects were not being rerendered by React even if their props changed. After doing some reading, I believe this is a documented limitation of the GeoJSON components. The fix seems to be to assign the GeoJSON components different keys each render, so React will treat them as different objects and not reuse them. A temporary fix has been put in place using Math.random, but this is inefficient. Once the code for all these fixes has been stabilized, we should replace the random key with one that updates only when new data is sent via props.

With these issues addressed, we're now seeing changes to the map colors when updating a visit level.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Our project hasn't been configured to use automated testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts