### PR TITLE
Make view friends travel button update travels dropdown

### DIFF
--- a/frontend/src/components/MapHeader/FriendDropdown.js
+++ b/frontend/src/components/MapHeader/FriendDropdown.js
@@ -3,25 +3,32 @@
 //== Friend Drop Down ==========================================================
 /*
   Please add documentation detailing the purpose and use of this component.
+
+  This component is the dropdown menu at the top of the travels page in the
+  center of the header bar. It allows the user to select which user's map they
+  wish to view.
 */
 
 //-- Dependencies --------------------------------
 import React, { Component } from 'react';
 import { Query, Mutation } from 'react-apollo';
 import { Dropdown } from 'semantic-ui-react';
+import { QUERY_CLIENT_TRAVELS } from '../../services/requests/travels';
 import {
   QUERY_MY_FRIENDS_HEADER,
-  MUTATION_VIEWFRIEND_HEADER } from '../../services/requests/header';
+  MUTATION_VIEWFRIEND_HEADER,
+} from '../../services/requests/header';
 
 
 export default class FriendDropdown extends Component {
   render() {
-    //query retrieves the userId from the apollo cache
+    // Outer query is necessary to determine if we're viewing a friend's travels
+    // Inner query retrieves the userId from the apollo cache
     return (
-      <React.Fragment>
+      <Query query={QUERY_CLIENT_TRAVELS}>{responseClientTravels => (
         <Query query={QUERY_MY_FRIENDS_HEADER}>
           {({ loading: loadingFriends, data: { me }}) => {
-            if (loadingFriends) {
+            if(responseClientTravels.loading || loadingFriends) {
               return (<div>Working on it</div>)
             }
             //takes the array of friends retrieved and maps through it to set the value of the dropdown options
@@ -35,7 +42,14 @@ export default class FriendDropdown extends Component {
               });
             }
             //adds the user to the top of the dropdown options array.
-            friendsList.unshift({ text: 'My Travels', value: me.id });
+            const myTravels = { text: 'My Travels', value: me.id };
+            friendsList.unshift(myTravels);
+            // Determine the starting value of the Dropdown list
+            let defaultTravels = myTravels.value;
+            const localState = responseClientTravels.data;
+            if(localState.viewingFriend && localState.friendId) {
+              defaultTravels = localState.friendId;
+            }
             //query returns a mutation that checks if the id passed is the same as the user id, and if not sets the apollo cache values for the friend being viewed and the related boolean.
             return (
               <Mutation mutation={MUTATION_VIEWFRIEND_HEADER}
@@ -54,13 +68,14 @@ export default class FriendDropdown extends Component {
                   icon="users"
                   options={friendsList}
                   search
+                  value={defaultTravels}
                 />
               )}
               </Mutation>
             );
           }}
         </Query>
-      </React.Fragment>
+      )}</Query>
     );
   }
 }


### PR DESCRIPTION
# Description

When users clicked the "view friend's travels" button on their friend's profile page, the user selection dropdown on the travels page wouldn't update to show that user by default. I added an extra query to retrieve the friend id from state, and have updated the dropdown accordingly.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status

- [x] Complete, but not tested (may need new tests)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts